### PR TITLE
Escaped quotes for dot.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -167,8 +167,9 @@ end
 
 function graph._dotEscape(str)
   if string.find(str, '[^a-zA-Z]') then
-    -- Escape newlines.
+    -- Escape newlines and quotes.
     local escaped = string.gsub(str, '\n', '\\n')
+    escaped = string.gsub(escaped, '"', '\\"')
     str = '"' .. escaped .. '"'
   end
   return str
@@ -180,7 +181,7 @@ end
   strings properly.
 ]]
 local function makeAttributeString(attributes)
-  str = {}
+  local str = {}
   for k, v in pairs(attributes) do
     table.insert(str, tostring(k) .. '=' .. graph._dotEscape(tostring(v)))
   end

--- a/test_graphviz.lua
+++ b/test_graphviz.lua
@@ -30,6 +30,8 @@ function tests.testDotEscape()
                 'Use quotes for non-alpha characters')
   tester:assert(graph._dotEscape('My\nnewline') == '"My\\nnewline"',
                 'Escape newlines')
+  tester:assert(graph._dotEscape('Say "hello"') == '"Say \\"hello\\""',
+                'Escape quotes')
 end
 
 


### PR DESCRIPTION
Previously the .dot file was invalid,
if a tooltip contained a text with " quotes.